### PR TITLE
throw SwordError for unparseable Atom entry swordapp/JavaServer2.0#6

### DIFF
--- a/src/main/java/org/swordapp/server/SwordAPIEndpoint.java
+++ b/src/main/java/org/swordapp/server/SwordAPIEndpoint.java
@@ -24,6 +24,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import org.apache.abdera.parser.ParseException;
 
 public class SwordAPIEndpoint
 {
@@ -347,12 +348,18 @@ public class SwordAPIEndpoint
 	}
 
 	protected void addDepositPropertiesFromEntry(Deposit deposit, HttpServletRequest req)
-			throws IOException
+			throws IOException, SwordError
 	{
 		InputStream entryPart = req.getInputStream();
 		Abdera abdera = new Abdera();
 		Parser parser = abdera.getParser();
-		Document<Entry> entryDoc = parser.parse(entryPart);
+		Document<Entry> entryDoc = null;
+		try {
+			entryDoc = parser.parse(entryPart);
+		}
+		catch (ParseException ex) {
+			throw new SwordError("Unable to parse SWORD entry: " + ex);
+		}
 		Entry entry = entryDoc.getRoot();
 		deposit.setEntry(entry);
 	}


### PR DESCRIPTION
By throwing a SwordError when `org.apache.abdera.parser.ParseException` is thrown from `parser.parse(entryPart)` I'm able to handle the exception in my application code, as explained in this ticket:

Fix Abdera ArrayIndexOutOfBoundsException with non-existent atom-entry-study.xml in SWORD jar (upstream ideally) · Issue #893 · IQSS/dataverse - https://github.com/IQSS/dataverse/issues/893

In case it's not obvious from the commit message or the title of this pull request, the bug I'm trying to fix on the SWORD library side is this one:

feeding an empty Atom entry file to CollectionAPI.post results in org.apache.abdera.parser.ParseException: java.lang.ArrayIndexOutOfBoundsException · Issue #6 · swordapp/JavaServer2.0 - https://github.com/swordapp/JavaServer2.0/issues/6
